### PR TITLE
updated packaging, removed deprecated calls to matplotlib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+.idea/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 <b>[This library is in active development and not currently recommended for public use.]</b>
 
 [![version status](https://img.shields.io/pypi/v/biolib.svg)](https://pypi.python.org/pypi/biolib)
+[![Bioconda](https://img.shields.io/conda/vn/bioconda/biolib.svg?color=43b02a)](https://anaconda.org/bioconda/biolib)
 
-Biolib is a python package for common tasks in bioinformatic.
+Biolib is a python package for common tasks in bioinformatics.
 
 ## Announcements
 
@@ -13,7 +14,10 @@ Biolib is a python package for common tasks in bioinformatic.
 ## Install
 
 The simplest way to install this package is through pip:
-> pip install biolib
+
+```shell
+python -m pip install biolib
+```
 
 ## Cite
 

--- a/biolib/VERSION
+++ b/biolib/VERSION
@@ -1,3 +1,6 @@
+0.1.9
+- updated packaging, removed deprecated calls to matplotlib
+
 0.1.8
 - added skip_species flag to decorate method
 

--- a/biolib/misc/time_keeper.py
+++ b/biolib/misc/time_keeper.py
@@ -17,6 +17,7 @@
 
 import time
 import logging
+from functools import reduce
 
 
 class TimeKeeper:

--- a/biolib/plots/scatter.py
+++ b/biolib/plots/scatter.py
@@ -134,18 +134,18 @@ class Scatter(AbstractPlot):
         for line in axes_scatter.xaxis.get_ticklines(): 
             line.set_color(self.axes_colour)
             
-        for loc, spine in axes_scatter.spines.iteritems():
+        for loc, spine in axes_scatter.spines.items():
             spine.set_color(self.axes_colour)
 
         # plot histograms
         if not show_histograms:
             for a in axes_scatter.yaxis.majorTicks:
-                    a.tick1On=True
-                    a.tick2On=False
+                    a.tick1line.set_visible(True)
+                    a.tick2line.set_visible(False)
                 
             for a in axes_scatter.xaxis.majorTicks:
-                    a.tick1On=True
-                    a.tick2On=False
+                    a.tick1line.set_visible(True)
+                    a.tick2line.set_visible(False)
                     
             for line in axes_scatter.yaxis.get_ticklines(): 
                 line.set_color(self.axes_colour)
@@ -153,7 +153,7 @@ class Scatter(AbstractPlot):
             for line in axes_scatter.xaxis.get_ticklines(): 
                 line.set_color(self.axes_colour)
 
-            for loc, spine in axes_scatter.spines.iteritems():
+            for loc, spine in axes_scatter.spines.items():
                     if loc in ['right','top']:
                             spine.set_color('none')
                     else:
@@ -164,8 +164,8 @@ class Scatter(AbstractPlot):
             x = [p_x, mq_x, hq_x]
             num_entries = sum([len(c) for c in x])
             weights = []
-            for c in xrange(0, len(x)):
-                w = [100.0/num_entries for _ in xrange(0, len(x[c]))]
+            for c in range(0, len(x)):
+                w = [100.0/num_entries for _ in range(0, len(x[c]))]
                 weights.append(w)
         
             # plot top histogram
@@ -209,12 +209,12 @@ class Scatter(AbstractPlot):
 
             # *** Prettify histogram plot
             for a in axes_top_histogram.yaxis.majorTicks:
-                    a.tick1On=False
-                    a.tick2On=True
+                    a.tick1line.set_visible(False)
+                    a.tick2line.set_visible(True)
                 
             for a in axes_top_histogram.xaxis.majorTicks:
-                    a.tick1On=True
-                    a.tick2On=False
+                    a.tick1line.set_visible(True)
+                    a.tick2line.set_visible(False)
                     
             for line in axes_top_histogram.yaxis.get_ticklines(): 
                 line.set_color(self.axes_colour)
@@ -222,19 +222,19 @@ class Scatter(AbstractPlot):
             for line in axes_top_histogram.xaxis.get_ticklines(): 
                 line.set_color(self.axes_colour)
 
-            for loc, spine in axes_top_histogram.spines.iteritems():
+            for loc, spine in axes_top_histogram.spines.items():
                     if loc in ['left','top']:
                             spine.set_color('none')
                     else:
                         spine.set_color(self.axes_colour)
 
             for a in axes_right_histogram.yaxis.majorTicks:
-                    a.tick1On=True
-                    a.tick2On=False
+                    a.tick1line.set_visible(True)
+                    a.tick2line.set_visible(False)
                 
             for a in axes_right_histogram.xaxis.majorTicks:
-                    a.tick1On=True
-                    a.tick2On=False
+                    a.tick1line.set_visible(True)
+                    a.tick2line.set_visible(False)
                     
             for line in axes_right_histogram.yaxis.get_ticklines(): 
                 line.set_color(self.axes_colour)
@@ -242,7 +242,7 @@ class Scatter(AbstractPlot):
             for line in axes_right_histogram.xaxis.get_ticklines(): 
                 line.set_color(self.axes_colour)
 
-            for loc, spine in axes_right_histogram.spines.iteritems():
+            for loc, spine in axes_right_histogram.spines.items():
                     if loc in ['right','top']:
                             spine.set_color('none') 
                     else:

--- a/biolib/plots/scatter2.py
+++ b/biolib/plots/scatter2.py
@@ -116,12 +116,12 @@ class Scatter2(AbstractPlot):
         # plot histograms
         if not show_histograms:
             for a in axes_scatter.yaxis.majorTicks:
-                    a.tick1On=True
-                    a.tick2On=False
+                    a.tick1line.set_visible(True)
+                    a.tick2line.set_visible(False)
                 
             for a in axes_scatter.xaxis.majorTicks:
-                    a.tick1On=True
-                    a.tick2On=False
+                    a.tick1line.set_visible(True)
+                    a.tick2line.set_visible(False)
                     
             for line in axes_scatter.yaxis.get_ticklines(): 
                 line.set_color(self.axes_colour)
@@ -129,7 +129,7 @@ class Scatter2(AbstractPlot):
             for line in axes_scatter.xaxis.get_ticklines(): 
                 line.set_color(self.axes_colour)
 
-            for loc, spine in axes_scatter.spines.iteritems():
+            for loc, spine in axes_scatter.spines.items():
                     if loc in ['right','top']:
                             spine.set_color('none')
                     else:
@@ -137,7 +137,7 @@ class Scatter2(AbstractPlot):
             
         else: # show histograms 
             # get bin weights for percentage histogram plot
-            weights = [100.0/len(x) for _ in xrange(0, len(x))]
+            weights = [100.0/len(x) for _ in range(0, len(x))]
         
             # plot top histogram
             axes_top_histogram.xaxis.set_major_formatter(NullFormatter())
@@ -178,12 +178,12 @@ class Scatter2(AbstractPlot):
 
             # *** Prettify histogram plot
             for a in axes_top_histogram.yaxis.majorTicks:
-                    a.tick1On=False
-                    a.tick2On=True
+                    a.tick1line.set_visible(False)
+                    a.tick2line.set_visible(True)
                 
             for a in axes_top_histogram.xaxis.majorTicks:
-                    a.tick1On=True
-                    a.tick2On=False
+                    a.tick1line.set_visible(True)
+                    a.tick2line.set_visible(False)
                     
             for line in axes_top_histogram.yaxis.get_ticklines(): 
                 line.set_color(self.axes_colour)
@@ -191,19 +191,19 @@ class Scatter2(AbstractPlot):
             for line in axes_top_histogram.xaxis.get_ticklines(): 
                 line.set_color(self.axes_colour)
 
-            for loc, spine in axes_top_histogram.spines.iteritems():
+            for loc, spine in axes_top_histogram.spines.items():
                     if loc in ['left','top']:
                             spine.set_color('none')
                     else:
                         spine.set_color(self.axes_colour)
 
             for a in axes_right_histogram.yaxis.majorTicks:
-                    a.tick1On=True
-                    a.tick2On=False
+                    a.tick1line.set_visible(True)
+                    a.tick2line.set_visible(False)
                 
             for a in axes_right_histogram.xaxis.majorTicks:
-                    a.tick1On=True
-                    a.tick2On=False
+                    a.tick1line.set_visible(True)
+                    a.tick2line.set_visible(False)
                     
             for line in axes_right_histogram.yaxis.get_ticklines(): 
                 line.set_color(self.axes_colour)
@@ -211,8 +211,8 @@ class Scatter2(AbstractPlot):
             for line in axes_right_histogram.xaxis.get_ticklines(): 
                 line.set_color(self.axes_colour)
 
-            for loc, spine in axes_right_histogram.spines.iteritems():
-                    if loc in ['right','top']:
+            for loc, spine in axes_right_histogram.spines.items():
+                    if loc in ['right', 'top']:
                             spine.set_color('none') 
                     else:
                         spine.set_color(self.axes_colour)

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     package_data={'biolib': ['VERSION']},
     url='http://pypi.python.org/pypi/biolib/',
     license='GPL3',
-    description='Package for common tasks in bioinformatic.',
+    description='Package for common tasks in bioinformatics.',
     long_description=long_description,
     long_description_content_type="text/markdown",
     classifiers=[
@@ -34,5 +34,5 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Topic :: Scientific/Engineering :: Bio-Informatics',
     ],
-    install_requires=[],
+    install_requires=['numpy', 'matplotlib', 'scipy'],
 )


### PR DESCRIPTION
Mainly resolves:

```
MatplotlibDeprecationWarning: 
The tick2On function was deprecated in Matplotlib 3.1 and will be removed in 3.3. Use Tick.tick2line.set_visible instead.
  a.tick2On = False
```